### PR TITLE
Persistent Block Indexing Patch

### DIFF
--- a/src/ParsonsInput.ts
+++ b/src/ParsonsInput.ts
@@ -85,6 +85,13 @@ export class ParsonsInput implements IParsonsInput {
         }
     }
 
+    public getBlockIndices = (): number[] => {
+        const blocks = this._dropArea.querySelectorAll('.parsons-block');
+        return Array.from(blocks).map(block =>
+            parseInt((block as HTMLDivElement).dataset.index || "-1")
+        );
+    }
+
     // getting the code from one block, and ignore tooltip text
     private _getTextFromBlock = (block: HTMLDivElement): string => {
         if (this.parentElement.language == 'raw') {
@@ -143,6 +150,7 @@ export class ParsonsInput implements IParsonsInput {
         // add new blocks
         for (let i = 0; i < this.blockOrder.length; ++i) {
             const newBlock = document.createElement('div');
+            newBlock.dataset.index = this.blockOrder[i].toString();
             this._dragArea.appendChild(newBlock);
             if (this.storedSourceBlocks[this.blockOrder[i]] === ' ') {
                 newBlock.innerHTML = '&nbsp;';

--- a/src/micro-parsons.ts
+++ b/src/micro-parsons.ts
@@ -120,6 +120,10 @@ export class MicroParsonsElement extends HTMLElement {
         return (this.hparsonsInput as ParsonsInput)._getTextArray();
     }
 
+    public getBlockIndices(): number[] {
+        return (this.hparsonsInput as ParsonsInput).getBlockIndices();
+    }
+
     public setCodeContext(props: {before: string | null, after: string | null}) {
         if (props.before) {
             this.codeBefore = props.before;


### PR DESCRIPTION
This PR introduces block identification via index attributes. It gives access to the block order, independent of its innerHTML, which can sometimes change.

This patch adds `data-index` metadata to each code block rendered by the ParsonsInput class and a public `getBlockIndices()` method that returns the current user block order as the original indices.

It affects:

`src/ParsonsInput.ts` (DOM modification and new method.)
`src/micro-parsons.ts` (API method)